### PR TITLE
README: Fix example yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ apache::resources:
   class:
     - apache
   class_params:
-    'apache'
+    apache:
       purge_configs: true
       default_vhost: false
       serveradmin: 'webmaster@example.com'


### PR DESCRIPTION
The colon is necessary, the quotes are optional here, but they are usually omitted.